### PR TITLE
Add `/status` route to backend

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,16 +8,10 @@ extern crate rocket_contrib;
 #[cfg(test)]
 mod tests;
 
-use rocket_contrib::json::{Json, JsonValue};
+use rocket_contrib::json::JsonValue;
 use rocket_cors::{AllowedOrigins, Cors, CorsOptions};
-use serde::Deserialize;
 
-#[derive(Deserialize)]
-struct Plan {
-    test: String,
-}
-
-// Need to support Cors for local development
+// TODO: Support the ability to configure allowed cors origins on a per environment basis.
 fn make_cors() -> Cors {
     let allowed_origins = AllowedOrigins::some_regex(&["^http://localhost:(.+)$"]);
 
@@ -29,15 +23,14 @@ fn make_cors() -> Cors {
     .expect("error while building Cors")
 }
 
-#[post("/plans", format = "application/json", data = "<plan>")]
-fn plans_create(plan: Json<Plan>) -> JsonValue {
-    json!({"status": plan.test})
+#[get("/status")]
+fn status() -> JsonValue {
+    json!({"status": "ok"})
 }
 
 fn create_rocket_server() -> rocket::Rocket {
-    // Eventually, we will only want to add the `cors` policy in dev.
     rocket::ignite()
-        .mount("/", routes![plans_create])
+        .mount("/", routes![status])
         .attach(make_cors())
 }
 

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -1,33 +1,16 @@
 use crate::create_rocket_server;
-use rocket::http::{ContentType, Status};
+use rocket::http::Status;
 use rocket::local::Client;
 
 #[test]
-fn post_plans() {
+fn get_status() {
     let client = create_client();
 
-    let mut res = client
-        .post("/plans")
-        .header(ContentType::JSON)
-        .body(r#"{ "test": "hi" }"#)
-        .dispatch();
+    let mut res = client.get("/status").dispatch();
 
     assert_eq!(res.status(), Status::Ok);
     let body = res.body().unwrap().into_string().unwrap();
-    assert!(body.contains("hi"));
-}
-
-#[test]
-fn post_plans_invalid_request() {
-    let client = create_client();
-
-    let res = client
-        .post("/plans")
-        .header(ContentType::JSON)
-        .body(r#"{ "invalid_key": "hi" }"#)
-        .dispatch();
-
-    assert_eq!(res.status(), Status::UnprocessableEntity);
+    assert!(body.contains("ok"));
 }
 
 fn create_client() -> Client {


### PR DESCRIPTION
My current focus is deploying a "working" frontend and backend on infra
as quickly as possible. By `working`, we mean a Rust app doing anything,
frontend doing anything, etc... For the Rust app, we will just define an
unauthenticated `status` endpoint.