### PR TITLE
Fix broken routing

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
-import App from "./App";
+import { BrowserRouter, Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
+
+import App from "./App";
 
 afterEach(() => {
   cleanup();
 });
 
 test("renders App component", () => {
-  const app = render(<App />);
+  const app = render(<App routerComponent={BrowserRouter} />);
   expect(app.getByTestId("home-container")).toBeInTheDocument();
 });
 
@@ -24,7 +26,7 @@ test("router correctly routes", () => {
   routesToTestId.forEach((testId, route) => {
     history.push(route);
 
-    const app = render(<App history={history} />);
+    const app = render(<App routerComponent={Router} history={history} />);
 
     expect(app.getByTestId(testId)).toBeInTheDocument();
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,17 +1,19 @@
 import React, { ReactElement } from "react";
-import { BrowserHistory, createBrowserHistory } from "history";
-import { Router, Switch, Route } from "react-router-dom";
+import { Switch, Route } from "react-router-dom";
+import { MemoryHistory } from "history";
 
 import About from "./components/about";
 import CreateMentalHealthPlan from "./components/createMentalHealthPlan";
 import Home from "./components/home";
 import Navbar from "./components/navbar";
 
-const defaultAppProps = {
-  history: createBrowserHistory(),
+// Setting the `routerComponent` to `React.ComponentType<any>` is pretty hacky... but I've already
+// spent more time than I want trying to figure out the types here...
+type AppProps = {
+  // eslint-disable-next-line
+  routerComponent: React.ComponentType<any>;
+  history?: MemoryHistory;
 };
-
-type AppProps = { history: BrowserHistory } & typeof defaultAppProps;
 
 function App(props: AppProps): ReactElement {
   const urlMap = {
@@ -23,7 +25,7 @@ function App(props: AppProps): ReactElement {
   // TODO: Decide if I want to extract an app router...
   // Right now, we won't, but we can down the line.
   return (
-    <Router history={props.history}>
+    <props.routerComponent history={props.history}>
       <div>
         <Navbar urlMap={urlMap} />
 
@@ -39,10 +41,8 @@ function App(props: AppProps): ReactElement {
           </Route>
         </Switch>
       </div>
-    </Router>
+    </props.routerComponent>
   );
 }
-
-App.defaultProps = defaultAppProps;
 
 export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { BrowserRouter } from "react-router-dom";
 
 // What is the safest way to limit the impact of any specific CSS framework?
 import "./App.sass";
@@ -8,7 +9,7 @@ import App from "./App";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <App routerComponent={BrowserRouter} />
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
I believe that the switch from `BrowserRouter` to `Router
history=createBrowserHistory()` broke our ability to actually navigate
via the web.

However, the change back to `BrowserHistory` would break our test suite.

Address by passing in the `browserComponent` as an argument to the `App`
argument. This lets me use one approach in testing and a different one
when running the actual app.

I punted a little bit on the types here... it was getting a little
confusing w.r.t. the proper type for the injected browserComponent. I
may revisit, or there may be a more elegant way to do this entirely.